### PR TITLE
Fixed download link for chacha template

### DIFF
--- a/apps/www/content/templates/chacha.mdx
+++ b/apps/www/content/templates/chacha.mdx
@@ -13,7 +13,7 @@ images:
     
 date: 2022-02-22
 live_preview: https://chachas.vercel.app
-source_code: https://github.com/Kinfe123/chachas
+source_code: https://github.com/Kinfe123/chacha
 stack_used: 
     - nextjs 
     - tailwind


### PR DESCRIPTION
Solving Issue #30. On the page https://www.farmui.com/templates/chacha, clicking on "Download Template" redirects users to an incorrect URL since it has an extra s in the end. I fixed it by replacing the link that directs users to the intended repo (https://github.com/Kinfe123/chacha) for chacha template.