### PR TITLE
chore: update the Link component(Breadcrumb) as it is overlapping with the navbar

### DIFF
--- a/apps/www/app/(www)/components/[slug]/page.tsx
+++ b/apps/www/app/(www)/components/[slug]/page.tsx
@@ -79,8 +79,8 @@ export default async ({ params: { slug } }: { params: Params }) => {
     );
     return (
       <>
-        <div className="">
-          <div className="z-30 flex items-center space-x-1 text-sm text-muted-foreground mb-10">
+        <div className="mt-16">
+          <div className="z-30 flex items-center space-x-1 text-sm text-muted-foreground mb-8">
             <Link
               href={"/components"}
               className="overflow-hidden cursor-pointer text-ellipsis whitespace-nowrap font-geistMono tracking-tight uppercase"


### PR DESCRIPTION
Fixed overlapping issue with the navbar and the Link component (breadcrumb) on the component page.

**Before :** 
<img width="1148" alt="Screenshot 2024-06-17 at 04 38 13" src="https://github.com/Kinfe123/farm-ui/assets/76902617/511ec451-bcdb-4e3f-a1ff-ba50b4c4760f"> 

**After :** 
<img width="1140" alt="Screenshot 2024-06-17 at 04 38 53" src="https://github.com/Kinfe123/farm-ui/assets/76902617/9cc87c2e-56d6-4533-b31e-464bfb2c0008">
